### PR TITLE
Option resorting not triggered

### DIFF
--- a/src/app/poll/poll.page.html
+++ b/src/app/poll/poll.page.html
@@ -110,6 +110,7 @@ Instead of having A% Y plus B% Z, you would then have C% X (or more, if even mor
 
 <ion-content *ngIf="ready && !!p" 
     (pointerup)="onBodyPointerup($event)"
+    (touchup)="onBodyTouchup($event)"
     [scrollEvents]="true"
     (ionScroll)="onScroll($event)"    
     >

--- a/src/app/poll/poll.page.ts
+++ b/src/app/poll/poll.page.ts
@@ -385,7 +385,7 @@ export class PollPage implements OnInit {
         }
       }  
     }
-    if (force || (this.show_live && this.needs_refresh && !(this.refresh_paused) && !this.dragged_oid)) {
+    if (force || (this.show_live && this.needs_refresh && !(this.refresh_paused))) {
       if (!force) {
         const loadingElement = await this.loadingController.create({
           message: this.translate.instant('poll.sorting'),
@@ -613,11 +613,7 @@ export class PollPage implements OnInit {
     // if clicking started in a slider, call that slider's pointerup handler:
     if (this.dragged_oid) {
       this.G.L.entry("onBodyPointerup");
-      // This variable needs to be saved before setting the timeout
-      // otherwise the timeout will point to de updated null dragged_oid
-      const previous_dragged_oid = this.dragged_oid
       this.onRatingColPointerup(this.dragged_oid, ev);
-      this.onRatingColPointerup(previous_dragged_oid, ev);
     }
     return true;
   }
@@ -629,11 +625,7 @@ export class PollPage implements OnInit {
     // if touching started in a slider, call that slider's touchup handler:
     if (this.dragged_oid) {
       this.G.L.entry("onBodyTouchup");
-      // This variable needs to be saved before setting the timeout
-      // otherwise the timeout will point to de updated null dragged_oid
-      const previous_dragged_oid = this.dragged_oid
       this.onRatingColTouchup(this.dragged_oid, ev);
-      this.onRatingColTouchup(previous_dragged_oid, ev);
     }
     return true;
   }

--- a/src/app/poll/poll.page.ts
+++ b/src/app/poll/poll.page.ts
@@ -613,7 +613,11 @@ export class PollPage implements OnInit {
     // if clicking started in a slider, call that slider's pointerup handler:
     if (this.dragged_oid) {
       this.G.L.entry("onBodyPointerup");
+      // This variable needs to be saved before setting the timeout
+      // otherwise the timeout will point to de updated null dragged_oid
+      const previous_dragged_oid = this.dragged_oid
       this.onRatingColPointerup(this.dragged_oid, ev);
+      this.onRatingColPointerup(previous_dragged_oid, ev);
     }
     return true;
   }
@@ -625,7 +629,11 @@ export class PollPage implements OnInit {
     // if touching started in a slider, call that slider's touchup handler:
     if (this.dragged_oid) {
       this.G.L.entry("onBodyTouchup");
+      // This variable needs to be saved before setting the timeout
+      // otherwise the timeout will point to de updated null dragged_oid
+      const previous_dragged_oid = this.dragged_oid
       this.onRatingColTouchup(this.dragged_oid, ev);
+      this.onRatingColTouchup(previous_dragged_oid, ev);
     }
     return true;
   }


### PR DESCRIPTION
Options were not being resorted because the function `onRatingColTouchup` was called with value `this.dragged_oid` only once. So even though the value changed, the second call to trigger the resorting was never made (as it is made when is triggered directly from the slider)

Closes #160