### PR TITLE
Missing Language

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -289,3 +289,10 @@ ion-spinner {
 .analysis {
     --min-height: 90%!important;
 }
+
+// NOTE: fix for ion-popover not appearing for languages
+// Alternatively, remove below and upgrade ionic to 6.5.2 or later
+// See: https://stackoverflow.com/a/76381282, https://stackoverflow.com/a/76382473
+ion-popover [popover]:not(:popover-open):not(dialog[open]) {
+    display: contents;
+}


### PR DESCRIPTION
# Issue
- Issue: https://github.com/pik-gane/vodle/issues/252
- RCA: `Found a 'popover' attribute with an invalid value.` when opening the ionic-dropdown which does not show the dropdown options
- Solution: https://stackoverflow.com/a/76381282

## Side note
Signed the CLA

# Evidence
https://github.com/pik-gane/vodle/assets/32838966/abb85d24-2c99-449e-a1a1-bb30211446c6


