### PR TITLE
Unexpected behavior on "draft poll" page

### DIFF
--- a/src/app/draftpoll/draftpoll.page.ts
+++ b/src/app/draftpoll/draftpoll.page.ts
@@ -41,7 +41,7 @@ import { environment } from 'src/environments/environment';
 
 import { unique_name_validator$ } from '../sharedcomponents/unique-form-validator';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators'
+import { map, startWith } from 'rxjs/operators'
 
 type option_data_t = { oid?, name?, desc?, url?, ratings? };
 
@@ -863,6 +863,7 @@ export class DraftpollPage implements OnInit {
 
   existingOptionName$(currentControlName: string): Observable<string[]> {
     return this.formGroup.valueChanges.pipe(
+      startWith({}),
       map(values => {
         const optionNameKeys = Object.keys(values as Object).filter(k => { return k.includes('option_name') && k !== currentControlName })
         const existingOptionNames: string[] = [];

--- a/src/app/sharedcomponents/unique-form-validator.ts
+++ b/src/app/sharedcomponents/unique-form-validator.ts
@@ -1,16 +1,26 @@
-import { AbstractControl, ValidationErrors, AsyncValidatorFn } from '@angular/forms';
-import { Observable } from 'rxjs';
-import { map, take } from 'rxjs/operators'
+import {
+  AbstractControl,
+  ValidationErrors,
+  AsyncValidatorFn,
+} from "@angular/forms";
+import { Observable, of } from "rxjs";
+import { map, take } from "rxjs/operators";
 
 /** The option-name has to be unique */
 
-export function unique_name_validator$(value$: Observable<string[]>): AsyncValidatorFn {
+export function unique_name_validator$(
+  value$: Observable<string[]>
+): AsyncValidatorFn {
   return (control: AbstractControl): Observable<ValidationErrors | null> => {
+    if (!control.valueChanges || control.pristine) {
+      return of(null);
+    }
+
     return value$.pipe(
-      map(names => {
+      map((names) => {
         return names.includes(control.value) ? { not_unique: true } : null;
       }),
       take(1)
-    )
+    );
   };
 }


### PR DESCRIPTION
# Issue
- Issue: https://github.com/pik-gane/vodle/issues/249
- RCA: Valid field async validator makes the field status "pending" due to not return null if the control is pristine or does not have valueChanges. Hence, the form is unable to determine whether the form is valid or not
- Solution: Return null when form control is pristine or does not have valueChanges

# Evidence
https://github.com/pik-gane/vodle/assets/32838966/8d76eceb-c0eb-40e9-b94a-7bfa15a4e10f


