### PR TITLE
Fix all 27 known-failing specs; save the multi-session work plan (#228)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,12 +2,11 @@
 # to main. Until this workflow existed, nothing ran the tests in CI, so every
 # "the suite passes" claim rested on someone's local run.
 #
-# The suite is not green: a number of "should create" specs fail on TestBed
-# dependency injection, and have done so independently of any current work.
-# Requiring a green suite would therefore make this job permanently red and so
-# permanently ignored. Instead the job fails on failures that are NOT in
-# test/known-failing-specs.txt, so a regression is loud while the pre-existing
-# breakage stays visible and countable in one file that is meant to shrink.
+# The job fails on failures that are NOT in test/known-failing-specs.txt.
+# That file is currently empty (the 27 TestBed dependency-injection failures
+# it was introduced for were fixed on 2026-09-09), so in effect a green suite
+# is required; the baseline mechanism stays in place so that a deliberately
+# accepted failure can be recorded explicitly instead of being normalized.
 name: tests
 
 on:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -265,12 +265,11 @@ $ npm run test:couchdb:stop
 
 `npm run test:couchdb` does the same for just that spec file.
 
-The suite is not green: a number of `should create` specs fail on TestBed
-dependency injection and have done so independently of the current work. They
-are listed in [test/known-failing-specs.txt](test/known-failing-specs.txt).
-CI (`.github/workflows/tests.yml`) fails on any failure that is *not* in that
-list, so a regression is loud while the pre-existing breakage stays visible;
-the list is meant to shrink to nothing. To make the same check locally:
+CI (`.github/workflows/tests.yml`) fails on any failure that is *not* listed
+in [test/known-failing-specs.txt](test/known-failing-specs.txt). That baseline
+is currently empty — the suite is expected to be green — and only a
+deliberately accepted failure may be recorded there, with a comment saying
+why. To make the same check locally:
 
 ```
 $ KARMA_RESULT_FILE=karma-results.json npx ng test --browsers=ChromeHeadlessNoSandbox --watch=false

--- a/planning/WORK_PLAN.md
+++ b/planning/WORK_PLAN.md
@@ -1,0 +1,106 @@
+# Multi-session work plan
+
+This is the issue-value analysis and session plan the work since 2026-09-05 has
+been following (originally drafted by an AI agent from the open issues; kept
+here verbatim so later sessions can pick up where the last one stopped).
+A status ledger follows at the end — update it when a session lands.
+
+---
+
+Most valuable issues in pik-gane/vodle and a multi-session work plan
+
+Context found in the repo
+
+vodle is mid-way through a major backend migration from CouchDB/PouchDB to Matrix (issue #293, PRs #294–#312, phases 1–16 complete, useMatrixBackend: true in both environments). Per SYNC_DEBUG_STATE.md and SESSION_SUMMARY_2025-02-17.md, real-time rating sync currently works only via a 15-second periodic-discovery fallback because matrix-js-sdk stops emitting state events after initial sync — root cause unknown. Meanwhile, the long-standing CouchDB sync-consistency bug family (#159, #161, #162, #163, #171, #251) remains open, and issue #292 contains the owner's concrete hardening plan for it.
+
+Value ranking of open issues
+
+Tier 1 — Strategic workstream (highest value):
+
+    #293 MVP for porting to Matrix — the active migration. Remaining: root-cause the SDK incremental-sync event emission failure, fix option resorting on reload, federation/offline testing, migration tooling validation, optional Phase 17 CouchDB cleanup.
+    #292 Critical consistency improvements for PouchDB caching/sync — owner-authored action plan that addresses the whole sync bug cluster (#159, #161, #162, #163, #171, #251) that plagues the production CouchDB path.
+
+Tier 2 — Urgent user-facing bugs (high value, small scope):
+
+    #273 Language selection empty, hindering login — blocks app use entirely; issue includes a suggested fix (default to English, never disable "next").
+    #186 Wrong waps on approval results explanation page — urgent + "ready to implement"; misleads users about results.
+    #251 Poll claims to have ended before deadline — urgent; likely resolved by #292 work.
+
+Tier 3 — Enabler:
+
+    #228 Set up proper testing — 346 migration tests already exist; extending coverage to the tally pipeline and sync layer de-risks Tiers 1–2. Milestoned for First Release.
+
+Tier 4 — Quick wins / housekeeping:
+
+    #98 Sorting options refresh — community PR #298 already open; just needs review/landing.
+    #57 Dark theme — likely closable: PR #291 already merged a dark theme implementation.
+    #214 simple formatting in details texts, #83 archive polls, #193 simplify first-time start — popular, "ready to implement" UX features.
+    Translation issues (#277 Tamil, #61 Arabic, #60 French, #56 Hindi, #54 Chinese) — mostly handled via Weblate (open PR #281).
+
+Session-by-session plan
+
+Session 1 — Urgent production fixes + housekeeping (Tier 2/4)
+
+    Fix #273: make login never blocked by an empty language list — populate from the i18n folder, fall back to English, root-cause the browser-language detection failure.
+    Fix #186: show effective waps instead of proxy waps on the approval-results explanation page.
+    Triage: review community PR #298 (fixes #98) and recommend merge/changes; verify #57 is satisfied by merged PR #291 and close it; close stale "OLD"-labeled issues (#11–#16) if confirmed obsolete.
+
+Session 2 — Matrix real-time sync root cause (#293)
+
+    Reproduce the two-client sync failure documented in SYNC_DEBUG_STATE.md; instrument the SDK sync loop to determine why incremental syncs emit no RoomState.events (suspects: in-memory-only store, SDK v37.5.0 bug, runtime-joined room re-emission path).
+    Fix the root cause (e.g., persistent IndexedDB store or SDK upgrade), keep the periodic-discovery fallback as a safety net, and fix the known "options not resorted after reload" issue.
+
+Session 3 — CouchDB consistency hardening, part 1 (#292)
+
+    Implement bootstrap ordering: complete cache bootstrap from PouchDB, record last_seq, start changes feed with since=last_seq only after bootstrap.
+    Add the change-event coalescing batcher and replication watchdog with stall detection, restart logic, and sync-status exposure to UI/logs. This targets #159 (syncing never ends) and #171 (incomplete uploads).
+
+Session 4 — CouchDB consistency hardening, part 2 (#292 → #161/#162/#251)
+
+    Add conflict detection (_conflicts) with deterministic resolution plus a startup background scan.
+    Make draft→running poll transitions transactional (confirm polldb writes before userdb deletes); mark optimistic cache updates pending-until-confirmed with rollback on failure.
+    Centralize authoritative-DB routing for all get/set/del; verify final tally waits for completed replication (fixes #161, #162, and likely #251).
+
+Session 5 — Testing infrastructure (#228)
+
+    Extend unit coverage to the tally pipeline (poll.service.ts) and DataService sync logic using the existing InMemoryBackend; add regression tests for each bug fixed in Sessions 1–4.
+    Stand up the existing e2e scaffolding (e2e/, test/ wdio) into a runnable smoke suite and wire tests into CI.
+
+Session 6 — Matrix migration hardening & completion (#293)
+
+    Offline/reconnect convergence testing, two-homeserver federation test, migration tooling (CouchDB→Matrix export) validation, E2EE for private polls, and the performance/security report the issue requests.
+    Only after production confidence: Phase 17 optional CouchDB code removal.
+
+Session 7 (optional) — UX features
+
+    #214 simple formatting in details texts, #83 archive polls, #193 simplified first-time onboarding.
+
+Rationale for this ordering
+
+    Session 1 ships small, independent, user-visible fixes immediately (a login blocker is the worst class of bug).
+    Sessions 2–4 attack the two competing backend workstreams in parallel tracks: Matrix must reach reliable real-time sync to ever replace CouchDB, while the CouchDB path serves production users today and its consistency bugs corrupt actual poll results.
+    Session 5's tests lock in the fixes before the riskier migration-completion work in Session 6.
+    Feature work (Session 7) comes last — new features on an unreliable sync layer would compound the consistency problems.
+
+---
+
+## Status ledger
+
+Update this section when a session's work lands; keep entries short and point
+at the PRs/commits that carry the detail.
+
+| Session | Status | Where |
+| --- | --- | --- |
+| 1 — urgent fixes | **done** (2026-09-05) | PR #314 (merged): #273 language fallback, #186 waps fix, keyboard-rating resort; #273/#98/#57 closed. #186 still open on GitHub — verify the merged fix satisfies it, then close. |
+| 2 — Matrix sync root cause | **done** (2026-09-05) | PR #315 (merged): incremental-sync root cause + option resorting after reload. Periodic-discovery fallback kept. |
+| 3 — CouchDB hardening part 1 | **done** (2026-09-06) | PR #316 (merged): bootstrap-gated sync, coalesced change batching, replication watchdog. |
+| 4 — CouchDB hardening part 2 | **in review** | PR #319 (open): conflict cleanup, transactional draft moves, centralized routing, ordered voter mutations, publication confirmation, guarded finalization. All review threads resolved as of 2026-09-09. |
+| 5 — testing infrastructure | **in progress** | On the PR #319 branch (2026-09-09): CI workflow `.github/workflows/tests.yml` (build + full suite on every PR, known-failure baseline in `test/known-failing-specs.txt`), real-CouchDB two-client integration suite (`src/app/data-service-couchdb-two-client.spec.ts` + `scripts/test-couchdb.sh`). The 27 baseline "should create" TestBed DI failures were fixed 2026-09-09 (shared plumbing in `src/app/testing/vodle-testing.ts`; baseline now empty, suite green). Remaining: extend tally-pipeline coverage, stand up the wdio e2e smoke suite. |
+| 6 — Matrix hardening & completion | not started | |
+| 7 — UX features | not started | PRs #254 (archive polls, #83) and #298 (#98) exist from the community and still need review. |
+
+Known debt that cuts across sessions (2026-09-09):
+
+- PR #319 is huge (~5000 added lines). Future consistency work should land in reviewable slices; the description's six numbered sections would have been six PRs.
+- `DataService.move_user_data` remains a TODO: on a credential change only in-flight voter-source writes are reconciled; the general user-data move between databases is still unimplemented.
+- No live multi-homeserver Matrix test exists yet (Session 6 will need the analogue of `scripts/test-couchdb.sh`).

--- a/src/app/about/about.page.spec.ts
+++ b/src/app/about/about.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { AboutPage } from './about.page';
 
 describe('AboutPage', () => {
@@ -29,7 +31,8 @@ describe('AboutPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ AboutPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(AboutPage);

--- a/src/app/addoption-dialog/addoption-dialog.page.spec.ts
+++ b/src/app/addoption-dialog/addoption-dialog.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { AddoptionDialogPage } from './addoption-dialog.page';
 
 describe('AddoptionDialogPage', () => {
@@ -29,7 +31,8 @@ describe('AddoptionDialogPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ AddoptionDialogPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(AddoptionDialogPage);

--- a/src/app/analysis/analysis.page.spec.ts
+++ b/src/app/analysis/analysis.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { AnalysisPage } from './analysis.page';
 
 describe('AnalysisPage', () => {
@@ -29,11 +31,18 @@ describe('AnalysisPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ AnalysisPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(AnalysisPage);
     component = fixture.componentInstance;
+    // AnalysisPage is opened as a modal with the poll page passed in; the
+    // template dereferences it, so the smoke test passes a minimal stand-in:
+    component.P = {
+      ready: false,
+      p: {am_abstaining: false, syncing: false, T: {n_not_abstaining: 0}},
+    } as any;
     fixture.detectChanges();
   }));
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { TestBed, waitForAsync } from '@angular/core/testing';
 
+import { TranslateModule } from '@ngx-translate/core';
+
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
@@ -28,6 +30,7 @@ describe('AppComponent', () => {
 
     TestBed.configureTestingModule({
       declarations: [AppComponent],
+      imports: [TranslateModule.forRoot()],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
   }));

--- a/src/app/assist/assist.page.spec.ts
+++ b/src/app/assist/assist.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { AssistPage } from './assist.page';
 
 describe('AssistPage', () => {
@@ -29,11 +31,19 @@ describe('AssistPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ AssistPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(AssistPage);
     component = fixture.componentInstance;
+    // AssistPage is opened as a modal with the poll page passed in; the
+    // template dereferences it, so the smoke test passes a minimal stand-in:
+    component.P = {
+      ready: false,
+      oidsorted: [],
+      p: {have_acted: false, syncing: false, options: {}},
+    } as any;
     fixture.detectChanges();
   }));
 

--- a/src/app/data.service.spec.ts
+++ b/src/app/data.service.spec.ts
@@ -18,6 +18,11 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { IonicModule } from '@ionic/angular';
+import { IonicStorageModule } from '@ionic/storage-angular';
+import { TranslateModule } from '@ngx-translate/core';
 import CryptoES from 'crypto-es';
 import * as PouchDB from 'pouchdb/dist/pouchdb';
 
@@ -30,7 +35,17 @@ describe('DataService', () => {
   let service: DataService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    // the real dependency graph; DataService's constructor is side-effect
+    // free (its init() runs only when GlobalService calls it):
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule,
+        HttpClientTestingModule,
+        IonicModule.forRoot(),
+        IonicStorageModule.forRoot(),
+        TranslateModule.forRoot(),
+      ],
+    });
     service = TestBed.inject(DataService);
   });
 

--- a/src/app/data.service.ts
+++ b/src/app/data.service.ts
@@ -496,6 +496,11 @@ export class DataService implements OnDestroy {
   }
 
   save_state(): Promise<any> {
+    if (!this.G) {
+      // the service was destroyed before init(G) ever ran (e.g. dependency
+      // injection teardown), so there is no state worth saving:
+      return Promise.resolve();
+    }
     this.G.L.entry("DataService.save_state");
     if (this.persisted_cache_invalid) {
       // a replicated change was terminally dropped, so the in-memory caches

--- a/src/app/delegation-dialog/delegation-dialog.page.spec.ts
+++ b/src/app/delegation-dialog/delegation-dialog.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { DelegationDialogPage } from './delegation-dialog.page';
 
 describe('DelegationDialogPage', () => {
@@ -29,7 +31,8 @@ describe('DelegationDialogPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ DelegationDialogPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(DelegationDialogPage);

--- a/src/app/delegation.service.spec.ts
+++ b/src/app/delegation.service.spec.ts
@@ -18,6 +18,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { TestBed } from '@angular/core/testing';
+import { IonicStorageModule } from '@ionic/storage-angular';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { DelegationService } from './delegation.service';
 
@@ -25,7 +27,11 @@ describe('DelegationService', () => {
   let service: DelegationService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    // the real dependency graph (TranslateService, MatrixService -> Storage);
+    // DelegationService's constructor is side-effect free:
+    TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot(), IonicStorageModule.forRoot()],
+    });
     service = TestBed.inject(DelegationService);
   });
 

--- a/src/app/delete-all/delete-all.page.spec.ts
+++ b/src/app/delete-all/delete-all.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { DeleteAllPage } from './delete-all.page';
 
 describe('DeleteAllPage', () => {
@@ -29,7 +31,8 @@ describe('DeleteAllPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ DeleteAllPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(DeleteAllPage);

--- a/src/app/delrespond/delrespond.page.spec.ts
+++ b/src/app/delrespond/delrespond.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { DelrespondPage } from './delrespond.page';
 
 describe('DelrespondPage', () => {
@@ -29,7 +31,8 @@ describe('DelrespondPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ DelrespondPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(DelrespondPage);

--- a/src/app/draftpoll-kebap/draftpoll-kebap.page.spec.ts
+++ b/src/app/draftpoll-kebap/draftpoll-kebap.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { DraftpollKebapPage } from './draftpoll-kebap.page';
 
 describe('DraftpollKebapPage', () => {
@@ -29,7 +31,8 @@ describe('DraftpollKebapPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ DraftpollKebapPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(DraftpollKebapPage);

--- a/src/app/draftpoll/draftpoll.page.spec.ts
+++ b/src/app/draftpoll/draftpoll.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { DraftpollPage } from './draftpoll.page';
 
 describe('DraftpollPage', () => {
@@ -29,7 +31,8 @@ describe('DraftpollPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ DraftpollPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(DraftpollPage);

--- a/src/app/explain-approval/explain-approval.page.spec.ts
+++ b/src/app/explain-approval/explain-approval.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { ExplainApprovalPage } from './explain-approval.page';
 
 describe('ExplainApprovalPage', () => {
@@ -29,11 +31,38 @@ describe('ExplainApprovalPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ ExplainApprovalPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(ExplainApprovalPage);
     component = fixture.componentInstance;
+    // ExplainApprovalPage is opened as a modal with the poll page and an
+    // option id passed in; its ngOnInit rebuilds the approval animation from
+    // the poll's tally (issue #186), so the stand-in needs an empty but
+    // well-formed tally:
+    const noop = () => {};
+    component.parent = {
+      G: {L: {entry: noop, exit: noop, trace: noop, debug: noop, info: noop, warn: noop, error: noop}},
+      oidsorted: ['o1'],
+      p: {
+        myvid: 'v1',
+        options: {o1: {name: 'Option 1'}},
+        tally_all: noop,
+        get_my_effective_rating: () => 0,
+        get_my_proxy_rating: () => 0,
+        T: {
+          effective_ratings_ascending_map: new Map(),
+          thresholds_map: new Map(),
+          approval_scores_map: new Map(),
+          n_not_abstaining: 0,
+          all_vids_set: new Set(),
+          votes_map: new Map(),
+          approvals_map: new Map([['o1', new Map()]]),
+        },
+      },
+    } as any;
+    component.oid = 'o1';
     fixture.detectChanges();
   }));
 

--- a/src/app/global.service.spec.ts
+++ b/src/app/global.service.spec.ts
@@ -18,18 +18,55 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { IonicModule } from '@ionic/angular';
+import { IonicStorageModule } from '@ionic/storage-angular';
+import { TranslateModule } from '@ngx-translate/core';
+import { LoggingServiceModule } from 'ionic-logging-service';
 
 import { GlobalService } from './global.service';
 
 describe('GlobalService', () => {
   let service: GlobalService;
+  // GlobalService's constructor globally replaces window.onerror and
+  // window.onunhandledrejection, which karma itself depends on to catch
+  // stray errors in later specs — so they must be restored afterwards:
+  let previous_onerror: any, previous_onrejection: any, previous_onbeforeunload: any;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    previous_onerror = window.onerror;
+    previous_onrejection = window.onunhandledrejection;
+    previous_onbeforeunload = window.onbeforeunload;
+    // the real dependency graph: constructing GlobalService boots the whole
+    // service tree (DataService.init and friends), which is exactly what
+    // "should be created" is supposed to prove works in a browser:
+    TestBed.configureTestingModule({
+      imports: [
+        LoggingServiceModule,
+        RouterTestingModule,
+        HttpClientTestingModule,
+        IonicModule.forRoot(),
+        IonicStorageModule.forRoot(),
+        TranslateModule.forRoot(),
+      ],
+      providers: [GlobalService],
+    });
     service = TestBed.inject(GlobalService);
+  });
+
+  afterEach(() => {
+    // stop the watchdog/sync machinery the boot started:
+    service.D.ngOnDestroy();
+    window.onerror = previous_onerror;
+    window.onunhandledrejection = previous_onrejection;
+    window.onbeforeunload = previous_onbeforeunload;
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+    // the constructor wired itself into the service tree (G is private):
+    expect((service.D as any).G).toBe(service);
+    expect((service.P as any).G).toBe(service);
   });
 });

--- a/src/app/help/help.page.spec.ts
+++ b/src/app/help/help.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { HelpPage } from './help.page';
 
 describe('HelpPage', () => {
@@ -29,7 +31,8 @@ describe('HelpPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ HelpPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(HelpPage);

--- a/src/app/imprint/imprint.page.spec.ts
+++ b/src/app/imprint/imprint.page.spec.ts
@@ -1,7 +1,9 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
-import { ImprintPage } from './imprint.page';
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
+import { ImprintPage, SafePipe } from './imprint.page';
 
 describe('ImprintPage', () => {
   let component: ImprintPage;
@@ -9,8 +11,9 @@ describe('ImprintPage', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ ImprintPage ],
-      imports: [IonicModule.forRoot()]
+      declarations: [ ImprintPage, SafePipe ],
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(ImprintPage);

--- a/src/app/inviteto/inviteto.page.spec.ts
+++ b/src/app/inviteto/inviteto.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { InvitetoPage } from './inviteto.page';
 
 describe('InvitetoPage', () => {
@@ -29,7 +31,8 @@ describe('InvitetoPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ InvitetoPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(InvitetoPage);

--- a/src/app/joinpoll/joinpoll.page.spec.ts
+++ b/src/app/joinpoll/joinpoll.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { JoinpollPage } from './joinpoll.page';
 
 describe('JoinpollPage', () => {
@@ -29,7 +31,8 @@ describe('JoinpollPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ JoinpollPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(JoinpollPage);

--- a/src/app/login/login.page.spec.ts
+++ b/src/app/login/login.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { LoginPage } from './login.page';
 
 describe('LoginPage', () => {
@@ -29,7 +31,8 @@ describe('LoginPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ LoginPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(LoginPage);

--- a/src/app/logout/logout.page.spec.ts
+++ b/src/app/logout/logout.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { LogoutPage } from './logout.page';
 
 describe('LogoutPage', () => {
@@ -29,7 +31,8 @@ describe('LogoutPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ LogoutPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(LogoutPage);

--- a/src/app/mypolls/mypolls.page.spec.ts
+++ b/src/app/mypolls/mypolls.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { MypollsPage } from './mypolls.page';
 
 describe('MypollsPage', () => {
@@ -29,7 +31,8 @@ describe('MypollsPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ MypollsPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(MypollsPage);

--- a/src/app/poll/poll.page.spec.ts
+++ b/src/app/poll/poll.page.spec.ts
@@ -18,7 +18,9 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { IonicModule } from '@ionic/angular';
+import { IonicModule, IonRouterOutlet } from '@ionic/angular';
+
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
 
 import { PollPage } from './poll.page';
 
@@ -29,7 +31,13 @@ describe('PollPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ PollPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: [
+        ...vodle_page_test_providers(),
+        // PollPage injects the router outlet for swipe-back control;
+        // in a smoke test a minimal stand-in suffices:
+        {provide: IonRouterOutlet, useValue: {swipeGesture: false}},
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(PollPage);

--- a/src/app/previewpoll/previewpoll.page.spec.ts
+++ b/src/app/previewpoll/previewpoll.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { PreviewpollPage } from './previewpoll.page';
 
 describe('PreviewpollPage', () => {
@@ -29,7 +31,8 @@ describe('PreviewpollPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ PreviewpollPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(PreviewpollPage);

--- a/src/app/privacy/privacy.page.spec.ts
+++ b/src/app/privacy/privacy.page.spec.ts
@@ -1,7 +1,9 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
-import { PrivacyPage } from './privacy.page';
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
+import { PrivacyPage, SafePipe } from './privacy.page';
 
 describe('PrivacyPage', () => {
   let component: PrivacyPage;
@@ -9,8 +11,9 @@ describe('PrivacyPage', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ PrivacyPage ],
-      imports: [IonicModule.forRoot()]
+      declarations: [ PrivacyPage, SafePipe ],
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(PrivacyPage);

--- a/src/app/settings/settings.page.spec.ts
+++ b/src/app/settings/settings.page.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../testing/vodle-testing';
+
 import { SettingsPage } from './settings.page';
 
 describe('SettingsPage', () => {
@@ -29,7 +31,8 @@ describe('SettingsPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ SettingsPage ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(SettingsPage);

--- a/src/app/sharedcomponents/select-server/select-server.component.spec.ts
+++ b/src/app/sharedcomponents/select-server/select-server.component.spec.ts
@@ -20,6 +20,8 @@ along with vodle. If not, see <https://www.gnu.org/licenses/>.
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
+import { VODLE_PAGE_TEST_IMPORTS, vodle_page_test_providers } from '../../testing/vodle-testing';
+
 import { SelectServerComponent } from './select-server.component';
 
 describe('SelectServerComponent', () => {
@@ -29,7 +31,8 @@ describe('SelectServerComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ SelectServerComponent ],
-      imports: [IonicModule.forRoot()]
+      imports: VODLE_PAGE_TEST_IMPORTS,
+      providers: vodle_page_test_providers()
     }).compileComponents();
 
     fixture = TestBed.createComponent(SelectServerComponent);

--- a/src/app/sharedcomponents/unique-form-validator.spec.ts
+++ b/src/app/sharedcomponents/unique-form-validator.spec.ts
@@ -5,7 +5,10 @@ import { Observable, of } from 'rxjs';
 describe('Unique form validator, async', () => {
 
   it('should return observable with null if the name does not exist', (done) => {
-    const ctrl = { value: 'California' };
+    // a pristine control (or one without valueChanges) short-circuits the
+    // validator, so the mock must look like a dirty, live control — otherwise
+    // both tests would only ever exercise the early return:
+    const ctrl = { value: 'California', valueChanges: of('California'), pristine: false };
     const av_fn: AsyncValidatorFn = unique_name_validator$(of(['Alaska']));
     const res = av_fn(ctrl as AbstractControl);
     (res as Observable<ValidationErrors | null>).subscribe(r => {
@@ -15,7 +18,7 @@ describe('Unique form validator, async', () => {
   });
 
   it('should return observable with saying it is not unique, if the name does exist', (done) => {
-    const ctrl = { value: 'California' };
+    const ctrl = { value: 'California', valueChanges: of('California'), pristine: false };
     const av_fn: AsyncValidatorFn = unique_name_validator$(of(['Alaska', 'California']));
     const res = av_fn(ctrl as AbstractControl);
     (res as Observable<ValidationErrors | null>).subscribe(r => {

--- a/src/app/testing/vodle-testing.ts
+++ b/src/app/testing/vodle-testing.ts
@@ -1,0 +1,116 @@
+/*
+(C) Copyright 2015–2022 Potsdam Institute for Climate Impact Research (PIK), authors, and contributors, see AUTHORS file.
+
+This file is part of vodle.
+
+vodle is free software: you can redistribute it and/or modify it under the 
+terms of the GNU Affero General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
+any later version.
+
+vodle is distributed in the hope that it will be useful, but WITHOUT ANY 
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR 
+A PARTICULAR PURPOSE. See the GNU Affero General Public License for more 
+details.
+
+You should have received a copy of the GNU Affero General Public License 
+along with vodle. If not, see <https://www.gnu.org/licenses/>. 
+*/
+
+/** Shared TestBed plumbing for component and service specs.
+ *
+ * The pages inject GlobalService, whose real constructor boots the entire
+ * service graph (databases, storage, spinner, sync). Component smoke tests
+ * therefore get a stub with just the members that templates and ngOnInit
+ * actually touch; the service specs wire the real dependency graph instead
+ * (see data.service.spec.ts / global.service.spec.ts).
+ */
+
+import { IonicModule } from '@ionic/angular';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { GlobalService } from '../global.service';
+
+export function silent_logger(): any {
+  const noop = () => {};
+  return {entry: noop, exit: noop, trace: noop, debug: noop, info: noop, warn: noop, error: noop};
+}
+
+export function global_service_stub(): any {
+  /** The members below are everything the smoke-tested templates and
+   *  ngOnInit()s dereference. Add here when a template gains a G.* binding —
+   *  a missing member fails the spec loudly, it does not silently pass. */
+  const stub: any = {
+    L: silent_logger(),
+    show_spinner: false,
+    open_url_in_new_tab: () => {},
+    map2str: (map: any) => '' + map,
+    go_home: () => {},
+    S: {
+      language: 'en',
+      email: '',
+      password: '',
+      use_guest: false,
+      consent: false,
+      // form validator referenced by the login and settings password groups:
+      passwords_match: () => null,
+      language_names: {en: 'English', de: 'Deutsch'},
+      validation_messages: {
+        email: [
+          {type: 'required', message: 'validation.email-required'},
+          {type: 'email', message: 'validation.email-valid'},
+        ],
+        password: [
+          {type: 'required', message: 'validation.password-required'},
+          {type: 'minlength', message: 'validation.password-length'},
+          {type: 'pattern', message: 'validation.password-pattern'},
+        ],
+        passwords_match: [
+          {message: 'validation.passwords-match'},
+        ],
+      },
+    },
+    D: {
+      ready: false,
+      fix_url: (url: string) => url,
+      format_date: () => '',
+      getu: () => '',
+      getp: () => '',
+      getv: () => '',
+      email_is_valid: () => false,
+      pid_is_draft: () => false,
+    },
+    P: {
+      polls: {},
+      ref_date: new Date(),
+      running_polls: [],
+      draft_polls: [],
+      closed_polls: [],
+      update_ref_date: () => {},
+    },
+    N: {
+      dismiss: () => {},
+      unseen: () => [],
+    },
+    Del: {},
+  };
+  return stub;
+}
+
+/** imports for a page/component smoke test */
+export const VODLE_PAGE_TEST_IMPORTS = [
+  IonicModule.forRoot(),
+  RouterTestingModule,
+  HttpClientTestingModule,
+  TranslateModule.forRoot(),
+  FormsModule,
+  ReactiveFormsModule,
+];
+
+/** providers for a page/component smoke test */
+export function vodle_page_test_providers(): any[] {
+  return [{provide: GlobalService, useValue: global_service_stub()}];
+}

--- a/test/known-failing-specs.txt
+++ b/test/known-failing-specs.txt
@@ -1,41 +1,12 @@
-# Specs that already fail without any current change, one exact spec name per line
-# (as reported by the json-result reporter in karma.conf.js: suites and the
-# spec description joined with " > ").
+# Specs that already fail without any current change, one exact spec name per
+# line (as reported by the json-result reporter in karma.conf.js: suites and
+# the spec description joined with " > ").
 #
-# scripts/check-test-results.js fails CI on any failure that is NOT listed here,
-# so this file is what separates a regression from the breakage that was already
-# there. It is meant to shrink to nothing.
+# scripts/check-test-results.js fails CI on any failure that is NOT listed
+# here, so this file is what separates a regression from breakage that was
+# already there.
 #
-# All entries below are TestBed dependency-injection failures of the shape
-#   NullInjectorError: R3InjectorError(DynamicTestModule)[... -> Router -> UrlSerializer]
-# i.e. the testing modules do not provide what the injected services need. They
-# fail on main as well. Because they are all "should create" smoke specs, no
-# component is currently covered by any executed test at all, which is why
-# fixing them is worth much more than the line count suggests.
-AboutPage > should create
-AddoptionDialogPage > should create
-AnalysisPage > should create
-AppComponent > should create the app
-AssistPage > should create
-DataService > should be created
-DelegationDialogPage > should create
-DelegationService > should be created
-DeleteAllPage > should create
-DelrespondPage > should create
-DraftpollKebapPage > should create
-DraftpollPage > should create
-ExplainApprovalPage > should create
-GlobalService > should be created
-HelpPage > should create
-ImprintPage > should create
-InvitetoPage > should create
-JoinpollPage > should create
-LoginPage > should create
-LogoutPage > should create
-MypollsPage > should create
-PollPage > should create
-PreviewpollPage > should create
-PrivacyPage > should create
-SelectServerComponent > should create
-SettingsPage > should create
-Unique form validator, async > should return observable with saying it is not unique, if the name does exist
+# The file is currently EMPTY: the 27 TestBed dependency-injection failures
+# that used to live here were fixed on 2026-09-09 (shared TestBed plumbing in
+# src/app/testing/vodle-testing.ts). Keep it empty — an entry may only be
+# added for a failure that is genuinely expected, with a comment saying why.


### PR DESCRIPTION
## Summary

Continues the testing workstream (plan session 5, #228) right after #319: the known-failure baseline that #319's CI introduced is emptied — **the full suite is now green** (606 passed / 0 failed / 0 skipped with a provisioned test CouchDB; 597 passed / 9 self-skipped integration specs without one), and CI now effectively requires green.

Also saves the multi-session work plan this line of work has been following as `planning/WORK_PLAN.md`, with a status ledger (sessions 1–3: PRs #314–#316; session 4: #319; session 5: in progress here).

## What the 27 failures were

All were TestBed dependency-injection errors in CLI-generated `should create` specs — the test modules provided nothing the constructors inject, so **no component or top-level service had a single executing test**. Fixes:

- `src/app/testing/vodle-testing.ts`: shared TestBed imports plus a `GlobalService` stub exposing exactly the members smoke-tested templates and `ngOnInit`s dereference (a missing member fails loudly). Component specs use the stub because the real `GlobalService` constructor boots the entire service graph.
- `DataService`/`DelegationService` specs wire the real dependency graph — their constructors are side-effect free.
- The `GlobalService` spec deliberately boots the real service tree (that is what "should be created" claims), and afterwards restores `window.onerror`/`onunhandledrejection`, which the constructor globally replaces and karma itself depends on.
- Modal pages (`Assist`, `Analysis`, `ExplainApproval`) get the `@Input` poll-page stand-in they dereference; `ExplainApproval` gets an empty but well-formed tally (its ngOnInit runs the #186 recompute path).
- `Imprint`/`Privacy` declare their own `SafePipe`.
- `unique-form-validator.spec`: the mock controls lacked `valueChanges`/`pristine`, so the validator always short-circuited — the "not unique" assertion could never pass and the "unique" one passed by accident. The controls now behave like live dirty controls.
- One real-code fix: `DataService.save_state()` guards against destruction before `init(G)` ever ran (DI teardown crashed in `ngOnDestroy → save_state → this.G.L`).

`test/known-failing-specs.txt` stays as a mechanism for *deliberately* accepted failures, but is empty; stale "suite is not green" prose in `tests.yml`/`INSTALL.md` updated accordingly.

## Validation

- Full suite with provisioned CouchDB (`scripts/test-couchdb.sh start`): **606 / 0 / 0**, `node scripts/check-test-results.js --no-skips` exits 0.
- Without CouchDB: 597 passed, 9 integration specs skip themselves, checker (without `--no-skips`) exits 0.
- The `tests` workflow on this PR is the enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)